### PR TITLE
fix bug in hpc runner

### DIFF
--- a/scriptflow/runners.py
+++ b/scriptflow/runners.py
@@ -165,8 +165,8 @@ class HpcRunner(AbstractRunner):
                 to_remove.append(k)
 
         for k in to_remove:
-            del self.processes[k]
-            controller.add_completed( p["job"] )
+            proc = self.processes.pop(k)
+            controller.add_completed(proc["job"])
 
     async def loop(self,controller):
         while True:


### PR DESCRIPTION
Fixes a small bug where `HpcRunner`'s `update` method incorrectly tries to "complete" the last task in its `processes` dictionary multiple times, rather than completing the tasks that have finished running.